### PR TITLE
Review Recurring Items keyboard shortcuts improvements (Issue #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,44 @@ Why yes, this is a cheap DALL-E generated icon. 😬
 MoneyMover is a Chrome extension that enhances the functionality of Lunch Money, a personal finance and budgeting tool.
 The goal of MoneyMover is to make small QoL enhancements to the site.
 
-Currently it only adds a few key-bindings:
+Currently it only adds a few key-bindings in different pages:
 
-- "n": Go to the "Next" month
-- "p": Go to the "Previous" month
-- "r": Click "Review Transactions" button
-- "t": Go to "this" month
-- "/": Focus and select the "Quick Filter" input
+### URL Unrestricted keybindings:
+- "j": Select next item in table
+- "k": Select previous item in table
 - "Escape": Overloaded
   - Clears applied filters (if any). It determines this on the presence of the "X Clear Filter" icon in any table.
   - Closes a modal (if open). It determines this based on a modal being open with a "close" or "cancel" button.
 - "Tab": Jumps between subnav menus (Hint: Use "+ Shift" to go backwards)
 
-At this point, all the keybindings are loosely based on Google Calendar's navigation keys.
+Note: when using j/k navigation a blue bar appears to the left of the selected row. This will currently cause a blank column to appear to the right of all other columns in the table. This does not affect functionality, but is a visual bug. This will likely need changes from Jen to support a small column to the left in all tables that the blue indicator can occupy.
+
+### Pages with Calendars:
+
+- "<": Go to the "Next" month
+- ">": Go to the "Previous" month
+- ".": Go to "this" month
+
+### /transactions/{date}
+- "x": Select row
+- "c": Focus category for current row
+- "p": Focus payee for current row
+- "a": Focus amount for current row (note that for imported transactions this will open the details pane)
+- "n": Focus notes for current row
+- "t": Add tag for current row
+- "r": Mark/unmark current row reviewed
+- "m": Mark selected rows reviewed
+- "Enter": Open details pane for current row
+- "/": Focus and select the "Quick Filter" input
+
+Note: some of these shortcuts may be fragile, particulraly for non-imported rows. This is because it relies on some attributes of the table, which may change.
+
+### /recurring/suggested
+- "Enter": Open details pane for current row
+- "n": Conditional: "No" button if Create rule dialog box is open, else "This is not a recurring item" if details pane is open.
+- "y": "Yes" button if Create rule dialog box is open
+- "a": "Approve this new recurring item" if details pane is open
+
 These keys should only trigger if the user is not focused on an input element.
 
 Future ideas:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Note: when using j/k navigation a bar appears to the left of the selected row. T
 - "Enter": Open details pane for current row
 - "/": Focus and select the "Quick Filter" input
 
-Note: some of these shortcuts may be fragile, particulraly for non-imported rows. This is because it relies on some attributes of the table, which may change.
+Note: some of these shortcuts may be fragile, particularly for non-imported rows. This is because it relies on some attributes of the table, which may change.
 
 ### /recurring/suggested
 - "Enter": Open details pane for current row

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ Future ideas:
 - User options to enable/disable/remap as they like.
 - Chrome Extension Store? (maybe)
 
+## A Note for Vimium users
+Many MoneyMover keyboard shortcuts are inspired by [Vim](https://www.vim.org/) and keyboard navigation fanatics may also have the [Vimium - The Hacker's Browser](https://vimium.github.io/) installed as well.
+
+MoneyMover overrides some of the default shortcuts for Vimium, so if you have both plugins installed please add ":https://my.lunchmoney.app/" to the list of Excluded URLs on the Vimium Plugin Options page.
+
 ## Table of Contents
 
 - [Setup](#setup)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Currently it only adds a few key-bindings in different pages:
   - Closes a modal (if open). It determines this based on a modal being open with a "close" or "cancel" button.
 - "Tab": Jumps between subnav menus (Hint: Use "+ Shift" to go backwards)
 
-Note: when using j/k navigation a blue bar appears to the left of the selected row. This will currently cause a blank column to appear to the right of all other columns in the table. This does not affect functionality, but is a visual bug. This will likely need changes from Jen to support a small column to the left in all tables that the blue indicator can occupy.
+Note: when using j/k navigation a bar appears to the left of the selected row. This will currently cause a blank column to appear to the right of all other columns in the table. This does not affect functionality, but is a visual bug. This will likely need changes from Jen to support a small column to the left in all tables that the blue indicator can occupy.
 
 ### Pages with Calendars:
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "autoprefixer": "^10.4.0",
+    "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "^6.8.1",
     "glob": "^7.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "MoneyMover",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A Chrome extension designed to give superpowers to Lunch Money",
   "main": "index.js",
   "scripts": {

--- a/src/TransactionTable.ts
+++ b/src/TransactionTable.ts
@@ -19,7 +19,7 @@ function setNewRowAsCurrent(newRow: HTMLTableRowElement | null) {
   lastActiveRowIndex = newRow?.rowIndex.toString() || "";
 }
 
-function getFirstNonPendingRow(): HTMLTableRowElement | null {
+function selectFirstRow(): HTMLTableRowElement | null {
   const tableBody = document.querySelector("tbody");
   if (!tableBody) {
     return null;
@@ -37,7 +37,7 @@ function getCurrentRow() {
     .querySelector("tbody")
     ?.querySelector("tr.keyboardSelected");
   if (!currentRow) {
-    currentRow = getFirstNonPendingRow();
+    currentRow = selectFirstRow();
   }
   if (!currentRow) {
     console.warn("Could not find any transaction rows in the table");
@@ -52,8 +52,8 @@ export const TransactionTable = {
   noSelectedRow() {
     return lastActiveRowIndex === "";
   },
-  getFirstNonPendingRow,
-  getNextNonPendingRow() {
+  selectFirstRow,
+  selectNextRow() {
     const currentRow = getCurrentRow();
     let row = currentRow?.nextElementSibling;
     while (isSkippableRow(row)) {
@@ -61,7 +61,7 @@ export const TransactionTable = {
     }
     setNewRowAsCurrent(row as HTMLTableRowElement | null);
   },
-  getPrevNonPendingRow() {
+  selectPrevRow() {
     const currentRow = getCurrentRow();
     let row = currentRow?.previousElementSibling;
     while (isSkippableRow(row)) {

--- a/src/TransactionTable/index.ts
+++ b/src/TransactionTable/index.ts
@@ -48,6 +48,9 @@ function getCurrentRow() {
 }
 
 export const TransactionTable = {
+  noSelectedRow() {
+    return lastActiveRowIndex === "";
+  },
   getFirstNonPendingRow,
   getNextNonPendingRow() {
     const currentRow = getCurrentRow();

--- a/src/TransactionTable/index.ts
+++ b/src/TransactionTable/index.ts
@@ -48,7 +48,6 @@ function getCurrentRow() {
 }
 
 export const TransactionTable = {
-  setNewRowAsCurrent,
   getFirstNonPendingRow,
   getNextNonPendingRow() {
     const currentRow = getCurrentRow();

--- a/src/TransactionTable/index.ts
+++ b/src/TransactionTable/index.ts
@@ -1,0 +1,90 @@
+// Global to preserve active row after editing a cell in it via keyboard
+let lastActiveRowIndex = "";
+
+function isSkippableRow(
+  row: Element | null | undefined
+): row is HTMLTableRowElement {
+  // This is the "Show/Hide pending transactions" row, skip it
+  return (
+    !!row && row.tagName === "TR" && !row.classList.contains("transaction-row")
+  );
+}
+
+function setNewRowAsCurrent(newRow: HTMLTableRowElement | null) {
+  document
+    .querySelector(".keyboardSelected")
+    ?.classList.remove("keyboardSelected");
+  newRow?.classList.add("keyboardSelected");
+  newRow?.scrollIntoView({ behavior: "smooth", block: "center" }); // Scroll the next item into view
+  lastActiveRowIndex = newRow?.rowIndex.toString() || "";
+}
+
+function getFirstNonPendingRow(): HTMLTableRowElement | null {
+  const tableBody = document.querySelector("tbody");
+  if (!tableBody) {
+    return null;
+  }
+  let firstItem: Element | null = tableBody?.querySelector("tr");
+  if (isSkippableRow(firstItem)) {
+    firstItem = firstItem.nextElementSibling;
+  }
+  setNewRowAsCurrent(firstItem as HTMLTableRowElement | null);
+  return firstItem as HTMLTableRowElement | null;
+}
+
+function getCurrentRow() {
+  let currentRow = document
+    .querySelector("tbody")
+    ?.querySelector("tr.keyboardSelected");
+  if (!currentRow) {
+    currentRow = getFirstNonPendingRow();
+  }
+  if (!currentRow) {
+    console.warn("Could not find any transaction rows in the table");
+    return null;
+  } else {
+    return currentRow;
+  }
+}
+
+export const TransactionTable = {
+  setNewRowAsCurrent,
+  getFirstNonPendingRow,
+  getNextNonPendingRow() {
+    const currentRow = getCurrentRow();
+    let row = currentRow?.nextElementSibling;
+    while (isSkippableRow(row)) {
+      row = row.nextElementSibling;
+    }
+    setNewRowAsCurrent(row as HTMLTableRowElement | null);
+  },
+  getPrevNonPendingRow() {
+    const currentRow = getCurrentRow();
+    let row = currentRow?.previousElementSibling;
+    while (isSkippableRow(row)) {
+      row = row.previousElementSibling;
+    }
+    setNewRowAsCurrent(row as HTMLTableRowElement | null);
+  },
+  // Function to reset the Transaction Keyboard Selection
+  resetTransactionKeyboardSelection() {
+    lastActiveRowIndex = "";
+  },
+  // Function to restore the last active row from after Transaction table update
+  restoreTransactionKeyboardSelection() {
+    if (lastActiveRowIndex !== "") {
+      const rowIndex = parseInt(lastActiveRowIndex);
+      if (!isNaN(rowIndex)) {
+        // Query the table body for the row element at the saved rowIndex
+        const querySelector = `tbody tr:nth-child(${rowIndex})`;
+        const rowElement = document.querySelector(querySelector);
+
+        // Set that current row ad Keyboard Selected and ensure it is in view
+        if (rowElement) {
+          rowElement.classList.add("keyboardSelected");
+          rowElement.scrollIntoView({ behavior: "smooth", block: "center" });
+        }
+      }
+    }
+  },
+};

--- a/src/TransactionTable/index.ts
+++ b/src/TransactionTable/index.ts
@@ -48,6 +48,7 @@ function getCurrentRow() {
 }
 
 export const TransactionTable = {
+  setNewRowAsCurrent,
   noSelectedRow() {
     return lastActiveRowIndex === "";
   },

--- a/src/content_script.tsx
+++ b/src/content_script.tsx
@@ -89,6 +89,11 @@ export const keyDownEventListener = (seq: ReturnType<typeof Sequencer>) =>
         tButton?.click();
         break;
       }
+      case "y": {
+        const yButton = getElementsForKey("y");
+        yButton?.click();
+        break;
+      }
       case "<": {
         const backButton = getElementsForKey("<");
         backButton?.click();

--- a/src/content_script.tsx
+++ b/src/content_script.tsx
@@ -37,11 +37,19 @@ export const keyDownEventListener = (seq: ReturnType<typeof Sequencer>) =>
     // else it's a one-shot keybinding
     switch (event.key) {
       case "j": {
-        TransactionTable.getNextNonPendingRow();
+        if (TransactionTable.noSelectedRow()) {
+          TransactionTable.getFirstNonPendingRow();
+        } else {
+          TransactionTable.getNextNonPendingRow();
+        }
         break;
       }
       case "k": {
-        TransactionTable.getPrevNonPendingRow();
+        if (TransactionTable.noSelectedRow()) {
+          TransactionTable.getFirstNonPendingRow();
+        } else {
+          TransactionTable.getPrevNonPendingRow();
+        }
         break;
       }
       case "c": {

--- a/src/content_script.tsx
+++ b/src/content_script.tsx
@@ -1,4 +1,8 @@
 import { getElementsForKey } from "@utils/getElementForKey";
+import { 
+  resetTransactionKeyboardSelection, 
+  restoreTransactionKeyboardSelection 
+} from "@utils/getElementForKey";
 import { initializeMessageListener } from "@messages/init";
 import { Sequencer } from "@utils/Sequencer";
 import "@styles/keyboard-shortcuts.css"
@@ -118,7 +122,10 @@ export const keyDownEventListener = (seq: ReturnType<typeof Sequencer>) =>
       }
       case "Enter": {
         const EnterButton = getElementsForKey("Enter");
-        EnterButton?.click();
+        if (EnterButton instanceof HTMLButtonElement) {
+          //else don't click as active row was re-selected
+          EnterButton?.click();
+        }
         break;
       }
       case "Escape": {
@@ -146,4 +153,83 @@ export const keyDownEventListener = (seq: ReturnType<typeof Sequencer>) =>
 
 const sequencer = Sequencer();
 document.addEventListener("keydown", keyDownEventListener(sequencer));
+
+// Going through hoops here to update the Keyboard Shortcuts selected
+// Transaction whenever the Transaction Table is re-rendered
+
+// Mutation Observer will restore the keyboard selection after re-render
+const mutationCallback = (mutationsList: MutationRecord[]) => {
+  for (const mutation of mutationsList) {
+    if ((mutation.type === 'childList') || (mutation.type === 'attributes')) {
+      const target = mutation.target;
+      if (target.nodeType === Node.ELEMENT_NODE) { 
+        const targetElement = target as Element; 
+        // If a transaction just got updated, restore the last active Keyboard Selection
+        if (targetElement.classList.contains('transaction-row') && 
+          (targetElement.classList.contains('cleared') || targetElement.classList.contains('uncleared')) && 
+          !targetElement.classList.contains('keyboardSelected')) {
+          restoreTransactionKeyboardSelection();
+        }
+      }
+    }
+  }
+};
+
+let observer = new MutationObserver(mutationCallback);
+let transactionTable: HTMLElement | null
+const config = { attributes: true, childList: true, subtree: true};
+
+// Function to enable the mutation monitor when Transaction Table is detectedd
+function monitorTransactionTable() {
+  // Called when the transactions page is loaded or updated.
+  // Since it can take time for the transactions table to load,
+  // wait for a bit and then if it is found monitor it for changes so that 
+  // the keyboard selected transaction persists across changes
+  setTimeout(() => {
+    transactionTable = document.querySelector('.p-transactions-table');
+    if (transactionTable) {
+      console.log("[MoneyMover] Keyboard Shortcuts enabled for transaction table.")
+      //transactionTable = document.getElementById('.p-transactions-table');
+      observer.observe(transactionTable, config);
+    } else {
+      console.log("[MoneyMover] Couldn't find transaction table for Keyboard Shortcuts.")
+    }
+  }, 3000); // Adjust the delay as needed
+}
+
+
+// Check for Transaction Table on an initial page load
+window.addEventListener('load', () => {
+  // Check if the transaction page is being loaded and set up a listener
+  // to monitor changes in the Transaction table
+  const currentUrl = window.location.href;  
+  if (currentUrl.includes("transactions")) {
+    onTransPage = true;
+    monitorTransactionTable()
+  } else {
+    onTransPage = false;
+  }
+});
+
+// Unfortunately, the only way I was able to consistently check for the
+// presence of the transaction table was to periodically check the current URL
+// when a lunchmoney tab is active
+let lastUrl = location.href; 
+let onTransPage = false;
+setInterval(() => {
+  const currentUrl = location.href;
+  if (currentUrl !== lastUrl) {
+    lastUrl = currentUrl; 
+    if (!onTransPage && currentUrl.includes("transactions")) {
+      onTransPage = true;
+      monitorTransactionTable()
+    } else if (onTransPage && (!currentUrl.includes("transactions"))) {
+      console.log("[Money Mover]Disconnecting Transactions Table monitor")
+      onTransPage = false;
+      resetTransactionKeyboardSelection()
+      observer.disconnect()
+    }
+  }
+}, 1000); // Check every 1000 milliseconds (1 second) - yes it's kludgy...
+
 console.log("🪄 MoneyMover intialized.");

--- a/src/content_script.tsx
+++ b/src/content_script.tsx
@@ -1,8 +1,9 @@
 import { getElementsForKey } from "@utils/getElementForKey";
 import { initializeMessageListener } from "@messages/init";
 import { Sequencer } from "@utils/Sequencer";
-import "@styles/keyboard-shortcuts.css";
 import { TransactionTable } from "@TransactionTable";
+
+import "@styles/keyboard-shortcuts.css";
 
 initializeMessageListener();
 

--- a/src/content_script.tsx
+++ b/src/content_script.tsx
@@ -100,7 +100,7 @@ export const keyDownEventListener = (seq: ReturnType<typeof Sequencer>) =>
         break;
       }
       case ".": {
-        const backToThisMonthButton = getElementsForKey("t");
+        const backToThisMonthButton = getElementsForKey(".");
         backToThisMonthButton?.click();
         break;
       }

--- a/src/content_script.tsx
+++ b/src/content_script.tsx
@@ -137,6 +137,7 @@ export const keyDownEventListener = (seq: ReturnType<typeof Sequencer>) =>
           getElementsForKey("Escape");
         clearFilterButton?.click();
         closeModalButton?.click();
+        TransactionTable.setNewRowAsCurrent(null);
         break;
       }
       case "Tab": {

--- a/src/content_script.tsx
+++ b/src/content_script.tsx
@@ -1,6 +1,7 @@
 import { getElementsForKey } from "@utils/getElementForKey";
 import { initializeMessageListener } from "@messages/init";
 import { Sequencer } from "@utils/Sequencer";
+import "@styles/keyboard-shortcuts.css"
 
 initializeMessageListener();
 
@@ -34,6 +35,24 @@ export const keyDownEventListener = (seq: ReturnType<typeof Sequencer>) =>
 
     // else it's a one-shot keybinding
     switch (event.key) {
+      case "j": {
+        const jButton = getElementsForKey("j");
+        break;
+      }
+      case "k": {
+        const kButton = getElementsForKey("k");
+        break;
+      }
+      case "c": {
+        const cButton = getElementsForKey("c");
+        cButton?.click();
+        break;
+      }
+      case "a": {
+        const aButton = getElementsForKey("a");
+        aButton?.click();
+        break;
+      }
       case "n": {
         const nextMonthButton = getElementsForKey("n");
         nextMonthButton?.click();
@@ -59,6 +78,11 @@ export const keyDownEventListener = (seq: ReturnType<typeof Sequencer>) =>
         const quickFilterInput = getElementsForKey("/");
         quickFilterInput?.focus();
         quickFilterInput?.select();
+        break;
+      }
+      case "Enter": {
+        const EnterButton = getElementsForKey("Enter");
+        EnterButton?.click();
         break;
       }
       case "Escape": {

--- a/src/content_script.tsx
+++ b/src/content_script.tsx
@@ -1,11 +1,8 @@
 import { getElementsForKey } from "@utils/getElementForKey";
-import { 
-  resetTransactionKeyboardSelection, 
-  restoreTransactionKeyboardSelection 
-} from "@utils/getElementForKey";
 import { initializeMessageListener } from "@messages/init";
 import { Sequencer } from "@utils/Sequencer";
-import "@styles/keyboard-shortcuts.css"
+import "@styles/keyboard-shortcuts.css";
+import { TransactionTable } from "@TransactionTable";
 
 initializeMessageListener();
 
@@ -40,13 +37,11 @@ export const keyDownEventListener = (seq: ReturnType<typeof Sequencer>) =>
     // else it's a one-shot keybinding
     switch (event.key) {
       case "j": {
-        const jButton = getElementsForKey("j");
-        //don't click as j is used to change selection
+        TransactionTable.getNextNonPendingRow();
         break;
       }
       case "k": {
-        const kButton = getElementsForKey("k");
-        //don't click as k is used to change selection
+        TransactionTable.getPrevNonPendingRow();
         break;
       }
       case "c": {
@@ -160,15 +155,18 @@ document.addEventListener("keydown", keyDownEventListener(sequencer));
 // Mutation Observer will restore the keyboard selection after re-render
 const mutationCallback = (mutationsList: MutationRecord[]) => {
   for (const mutation of mutationsList) {
-    if ((mutation.type === 'childList') || (mutation.type === 'attributes')) {
+    if (mutation.type === "childList" || mutation.type === "attributes") {
       const target = mutation.target;
-      if (target.nodeType === Node.ELEMENT_NODE) { 
-        const targetElement = target as Element; 
+      if (target.nodeType === Node.ELEMENT_NODE) {
+        const targetElement = target as Element;
         // If a transaction just got updated, restore the last active Keyboard Selection
-        if (targetElement.classList.contains('transaction-row') && 
-          (targetElement.classList.contains('cleared') || targetElement.classList.contains('uncleared')) && 
-          !targetElement.classList.contains('keyboardSelected')) {
-          restoreTransactionKeyboardSelection();
+        if (
+          targetElement.classList.contains("transaction-row") &&
+          (targetElement.classList.contains("cleared") ||
+            targetElement.classList.contains("uncleared")) &&
+          !targetElement.classList.contains("keyboardSelected")
+        ) {
+          TransactionTable.restoreTransactionKeyboardSelection();
         }
       }
     }
@@ -176,36 +174,39 @@ const mutationCallback = (mutationsList: MutationRecord[]) => {
 };
 
 let observer = new MutationObserver(mutationCallback);
-let transactionTable: HTMLElement | null
-const config = { attributes: true, childList: true, subtree: true};
+let transactionTable: HTMLElement | null;
+const config = { attributes: true, childList: true, subtree: true };
 
 // Function to enable the mutation monitor when Transaction Table is detectedd
 function monitorTransactionTable() {
   // Called when the transactions page is loaded or updated.
   // Since it can take time for the transactions table to load,
-  // wait for a bit and then if it is found monitor it for changes so that 
+  // wait for a bit and then if it is found monitor it for changes so that
   // the keyboard selected transaction persists across changes
   setTimeout(() => {
-    transactionTable = document.querySelector('.p-transactions-table');
+    transactionTable = document.querySelector(".p-transactions-table");
     if (transactionTable) {
-      console.log("[MoneyMover] Keyboard Shortcuts enabled for transaction table.")
+      console.log(
+        "[MoneyMover] Keyboard Shortcuts enabled for transaction table."
+      );
       //transactionTable = document.getElementById('.p-transactions-table');
       observer.observe(transactionTable, config);
     } else {
-      console.log("[MoneyMover] Couldn't find transaction table for Keyboard Shortcuts.")
+      console.log(
+        "[MoneyMover] Couldn't find transaction table for Keyboard Shortcuts."
+      );
     }
   }, 3000); // Adjust the delay as needed
 }
 
-
 // Check for Transaction Table on an initial page load
-window.addEventListener('load', () => {
+window.addEventListener("load", () => {
   // Check if the transaction page is being loaded and set up a listener
   // to monitor changes in the Transaction table
-  const currentUrl = window.location.href;  
+  const currentUrl = window.location.href;
   if (currentUrl.includes("transactions")) {
     onTransPage = true;
-    monitorTransactionTable()
+    monitorTransactionTable();
   } else {
     onTransPage = false;
   }
@@ -214,20 +215,20 @@ window.addEventListener('load', () => {
 // Unfortunately, the only way I was able to consistently check for the
 // presence of the transaction table was to periodically check the current URL
 // when a lunchmoney tab is active
-let lastUrl = location.href; 
+let lastUrl = location.href;
 let onTransPage = false;
 setInterval(() => {
   const currentUrl = location.href;
   if (currentUrl !== lastUrl) {
-    lastUrl = currentUrl; 
+    lastUrl = currentUrl;
     if (!onTransPage && currentUrl.includes("transactions")) {
       onTransPage = true;
-      monitorTransactionTable()
-    } else if (onTransPage && (!currentUrl.includes("transactions"))) {
-      console.log("[Money Mover]Disconnecting Transactions Table monitor")
+      monitorTransactionTable();
+    } else if (onTransPage && !currentUrl.includes("transactions")) {
+      console.log("[Money Mover]Disconnecting Transactions Table monitor");
       onTransPage = false;
-      resetTransactionKeyboardSelection()
-      observer.disconnect()
+      TransactionTable.resetTransactionKeyboardSelection();
+      observer.disconnect();
     }
   }
 }, 1000); // Check every 1000 milliseconds (1 second) - yes it's kludgy...

--- a/src/content_script.tsx
+++ b/src/content_script.tsx
@@ -37,13 +37,16 @@ export const keyDownEventListener = (seq: ReturnType<typeof Sequencer>) =>
     switch (event.key) {
       case "j": {
         const jButton = getElementsForKey("j");
+        //don't click as j is used to change selection
         break;
       }
       case "k": {
         const kButton = getElementsForKey("k");
+        //don't click as k is used to change selection
         break;
       }
       case "c": {
+        event.preventDefault(); //prevent typing c in category field
         const cButton = getElementsForKey("c");
         cButton?.click();
         break;
@@ -54,21 +57,49 @@ export const keyDownEventListener = (seq: ReturnType<typeof Sequencer>) =>
         break;
       }
       case "n": {
-        const nextMonthButton = getElementsForKey("n");
-        nextMonthButton?.click();
+        event.preventDefault(); //don't type n in notes field
+        const nButton = getElementsForKey("n");
+        nButton?.click();
         break;
       }
       case "p": {
-        const previousMonthButton = getElementsForKey("p");
-        previousMonthButton?.click();
+        event.preventDefault(); //don't type p in payee field
+        const pButton = getElementsForKey("p");
+        pButton?.click();
+        break;
+      }
+      case "x": {
+        const xButton = getElementsForKey("x");
+        xButton?.click();
+        break;
+      }
+      case "m": {
+        const mButton = getElementsForKey("m");
+        mButton?.click();
         break;
       }
       case "r": {
-        const reviewTransactionsButton = getElementsForKey("r");
-        reviewTransactionsButton?.click();
+        const rButton = getElementsForKey("r");
+        rButton?.click();
         break;
       }
       case "t": {
+        event.preventDefault(); //don't type t in tags field
+        const tButton = getElementsForKey("t");
+        tButton?.click();
+        break;
+      }
+      case "<": {
+        const backButton = getElementsForKey("<");
+        backButton?.click();
+        break;
+      }
+      case ">": {
+        const forwardButton = getElementsForKey(">");
+        forwardButton?.click();
+        break;
+      }
+      case ".": {
         const backToThisMonthButton = getElementsForKey("t");
         backToThisMonthButton?.click();
         break;

--- a/src/content_script.tsx
+++ b/src/content_script.tsx
@@ -39,17 +39,17 @@ export const keyDownEventListener = (seq: ReturnType<typeof Sequencer>) =>
     switch (event.key) {
       case "j": {
         if (TransactionTable.noSelectedRow()) {
-          TransactionTable.getFirstNonPendingRow();
+          TransactionTable.selectFirstRow();
         } else {
-          TransactionTable.getNextNonPendingRow();
+          TransactionTable.selectNextRow();
         }
         break;
       }
       case "k": {
         if (TransactionTable.noSelectedRow()) {
-          TransactionTable.getFirstNonPendingRow();
+          TransactionTable.selectFirstRow();
         } else {
-          TransactionTable.getPrevNonPendingRow();
+          TransactionTable.selectPrevRow();
         }
         break;
       }

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -160,10 +160,6 @@ const recurringKeybindings = [
 const Popup = () => {
   return (
     <div className={"w-[575px] rounded-md shadow-md p-8 text-md"}>
-      <p className={"text-sm italic"}>
-        MoneyMover: A Chrome Extension designed to give Lunch Money superpowers
-      </p>
-
       <div className={"my-8"}>
         <p className={"font-bold"}>What does it do?</p>
         <p>
@@ -282,13 +278,6 @@ const Popup = () => {
           ))}
         </ul>
       </div>
-
-
-      <p className={"mt-4"}>
-        At this point, all the keybindings are loosely based on Google
-        Calendar's navigation keys. These keys should only trigger if the user
-        is not focused on an input element.
-      </p>
     </div>
   );
 };

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -41,20 +41,24 @@ function clickElement(key: string) {
 
 const keybindings = [
   {
-    key: "n",
+    key: ">",
     description: "Go to the 'Next' month",
   },
   {
-    key: "p",
+    key: "<",
     description: "Go to the 'Previous' month",
   },
   {
-    key: "r",
-    description: "Click 'Review Transactions' button",
+    key: ".",
+    description: "Go to 'this' month",
   },
   {
-    key: "t",
-    description: "Go to 'this' month",
+    key: "j",
+    description: "Move down a row in a table",
+  },
+  {
+    key: "k",
+    description: "Move up a row in a table",
   },
   {
     key: "/",
@@ -82,6 +86,77 @@ const keybindings = [
   },
 ];
 
+const transactionKeybindings = [
+  {
+    key: "x",
+    description: "Select transaction for bulk edit",
+  },
+  {
+    key: "c",
+    description: "Change 'Category'",
+  },
+  {
+    key: "p",
+    description: "Change 'Payee'",
+  },
+  {
+    key: "a",
+    description: "Change 'Amount'",
+  },
+  {
+    key: "n",
+    description: "Change 'Notes'",
+  },
+  {
+    key: "t",
+    description: "Add Tag",
+  },
+  {
+    key: "r",
+    description: "Mark/Unmark current transaction reviewed",
+  },
+  {
+    key: "m",
+    description: "Mark selected transactions reviewed",
+  },
+  {
+    key: "Enter",
+    description: "Open details pane for selected transaction",
+  },
+  {
+    key: "/",
+    description: "Quick Filter",
+  },
+]
+
+const recurringKeybindings = [
+  {
+    key: "Enter",
+    description: "Open details pane for current row",
+  },
+  {
+    key: "n",
+    description:
+      "This key is 'Overloaded' meaning it works differently depending on the UI state",
+    overloads: [
+      {
+        description: "'No' button if Create rule dialog box is open.",
+      },
+      {
+        description: "'This is not a recurring item' if details pane is open."
+      },
+    ],    
+  },
+  {
+    key: "y",
+    description: "'Yes' button if Create rule dialog box is open.",
+  },
+  {
+    key: "a",
+    description: "'Approve this new recurring item' if details pane is open",
+  },
+]
+
 const Popup = () => {
   return (
     <div className={"w-[575px] rounded-md shadow-md p-8 text-md"}>
@@ -99,7 +174,7 @@ const Popup = () => {
       </div>
 
       <div className="my-8">
-        <p className={"font-semibold text-2xl mb-4"}>Key Bindings:</p>
+        <p className={"font-semibold text-2xl mb-4"}>Global Key Bindings:</p>
         <ul className={"ml-4 list-disc"}>
           {keybindings.map((binding, i) => (
             <li
@@ -136,6 +211,79 @@ const Popup = () => {
           ))}
         </ul>
       </div>
+
+      <div className="my-8">
+        <p className={"font-semibold text-2xl mb-4"}>Transactions Page:</p>
+        <ul className={"ml-4 list-disc"}>
+          {transactionKeybindings.map((binding, i) => (
+            <li
+              className={"hover:cursor-help"}
+              key={i}
+              onMouseEnter={() => {
+                highlightElement(binding.key);
+              }}
+              onMouseLeave={() => {
+                unhighlightElement(binding.key);
+              }}
+              onClick={() => {
+                clickElement(binding.key);
+              }}
+            >
+              <div className={"mb-2"}>
+                <span
+                  className={
+                    "font-semibold p-1 bg-gray-100 rounded-md border border-stone-200 min-w-[20px] inline-flex justify-center"
+                  }
+                >
+                  {binding.key}
+                </span>
+                <span className={"ml-3"}>{binding.description}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="my-8">
+        <p className={"font-semibold text-2xl mb-4"}>Recurring Page:</p>
+        <ul className={"ml-4 list-disc"}>
+          {recurringKeybindings.map((binding, i) => (
+            <li
+              className={"hover:cursor-help"}
+              key={i}
+              onMouseEnter={() => {
+                highlightElement(binding.key);
+              }}
+              onMouseLeave={() => {
+                unhighlightElement(binding.key);
+              }}
+              onClick={() => {
+                clickElement(binding.key);
+              }}
+            >
+              <div className={"mb-2"}>
+                <span
+                  className={
+                    "font-semibold p-1 bg-gray-100 rounded-md border border-stone-200 min-w-[20px] inline-flex justify-center"
+                  }
+                >
+                  {binding.key}
+                </span>
+                <span className={"ml-3"}>{binding.description}</span>
+              </div>
+              {binding.overloads && (
+                <ul className={"ml-4 list-disc"}>
+                  {binding.overloads.map((overload, i) => (
+                    <li key={i}>{overload.description}</li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+
       <p className={"mt-4"}>
         At this point, all the keybindings are loosely based on Google
         Calendar's navigation keys. These keys should only trigger if the user

--- a/src/styles/keyboard-shortcuts.css
+++ b/src/styles/keyboard-shortcuts.css
@@ -1,0 +1,13 @@
+.keyboardSelected {
+  position: relative;
+}
+
+.keyboardSelected::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 4px; /* Adjust the width as needed */
+  height: 100%; /* Full height of the <tr> element */
+  background-color: blue; /* Color of the bar */
+}

--- a/src/styles/keyboard-shortcuts.css
+++ b/src/styles/keyboard-shortcuts.css
@@ -9,5 +9,5 @@
   left: 0;
   width: 4px; /* Adjust the width as needed */
   height: 100%; /* Full height of the <tr> element */
-  background-color: blue; /* Color of the bar */
+  background-color: #fbb700; /* LunchMoney Yellow */
 }

--- a/src/utils/Sequencer.ts
+++ b/src/utils/Sequencer.ts
@@ -1,8 +1,9 @@
 import { getElementsForSequence } from "@utils/getElementsForSequence";
+import { TransactionTable } from "@TransactionTable";
 
 export function Sequencer() {
   let sequence = "";
-  const validSequences = ["gb", "gt"];
+  const validSequences = ["gb", "gt", "gg"];
   return {
     add: function (key: string) {
       sequence += key;
@@ -33,6 +34,10 @@ export function Sequencer() {
         case "gt": {
           const budgetLink = getElementsForSequence("gt");
           budgetLink?.click();
+          break;
+        }
+        case "gg": {
+          TransactionTable.getFirstNonPendingRow();
           break;
         }
       }

--- a/src/utils/Sequencer.ts
+++ b/src/utils/Sequencer.ts
@@ -37,7 +37,7 @@ export function Sequencer() {
           break;
         }
         case "gg": {
-          TransactionTable.getFirstNonPendingRow();
+          TransactionTable.selectFirstRow();
           break;
         }
       }

--- a/src/utils/getElementForKey.ts
+++ b/src/utils/getElementForKey.ts
@@ -7,9 +7,27 @@ export const query = (selector: string) =>
 export const queryAll = (selector: string) =>
   Array.from(document.querySelectorAll(selector) as NodeListOf<HTMLElement>);
 
-const UrlsWithMonths = [".*\/(transactions|budget|recurring|calendar)\/\d*"];
+const UrlsWithMonths = [".*/(transactions|budget|recurring|calendar)/d*"];
 
-type Key = "j" | "k" | "c" | "a" | "n" | "p" | "x" | "m" | "r" | "t" | "y" | ">" | "<" | "." | "/" | "Enter" | "Escape" | "Tab";
+type Key =
+  | "j"
+  | "k"
+  | "c"
+  | "a"
+  | "n"
+  | "p"
+  | "x"
+  | "m"
+  | "r"
+  | "t"
+  | "y"
+  | ">"
+  | "<"
+  | "."
+  | "/"
+  | "Enter"
+  | "Escape"
+  | "Tab";
 type ElementsForKey = {
   [K in Key]: K extends "/"
     ? HTMLInputElement | null
@@ -18,43 +36,8 @@ type ElementsForKey = {
     : HTMLElement | null;
 };
 
-// Global to preserve active row after editing a cell in it via keyboard
-let lastActiveRowIndex = ""
-
 function isUrlOneOf(url: string, allowedUrls: string[]) {
-  return allowedUrls.some(pattern => url.match(pattern))
-}
-
-function getFirstNonPendingRow(tableBody: HTMLTableSectionElement | null, goingUp: boolean): HTMLTableRowElement | null {
-  if (!tableBody) {
-    return null;
-  }
-  let firstItem: Element | null = tableBody?.querySelector("tr");
-  if (firstItem && firstItem.tagName === 'TR' && !firstItem.classList.contains('transaction-row')) {
-    // This is the "Show/Hide pending transactions" row, skip it
-    firstItem = goingUp ? firstItem.previousElementSibling : firstItem.nextElementSibling;
-  }
-  return firstItem as HTMLTableRowElement | null;
-}
-
-function getNextNonPendingRow(currentRow: Element | null, goingUp: boolean): HTMLTableRowElement | null {
-  if (!currentRow) {
-    return null;
-  }
-
-  let row: Element | null = goingUp ? currentRow.previousElementSibling : currentRow.nextElementSibling;  
-  while (row && row.tagName === 'TR' && !row.classList.contains('transaction-row')) {
-    // This is the "Show/Hide pending transactions" row, skip it
-    row = goingUp ? row.previousElementSibling : row.nextElementSibling;
-  }
-  return row as HTMLTableRowElement | null;
-}
-
-function setNewRowAsCurrent(newRow: HTMLTableRowElement | null, previous: HTMLTableRowElement | null) {
-  previous?.classList.remove('keyboardSelected');
-  newRow?.classList.add('keyboardSelected');
-  newRow?.scrollIntoView({ behavior: 'smooth', block: 'center' }); // Scroll the next item into view
-  lastActiveRowIndex = (newRow?.rowIndex.toString() || "");
+  return allowedUrls.some((pattern) => url.match(pattern));
 }
 
 export function getElementsForKey(key: "j"): HTMLElement | null;
@@ -73,44 +56,15 @@ export function getElementsForKey(key: "<"): HTMLElement | null;
 export function getElementsForKey(key: "."): HTMLElement | null;
 export function getElementsForKey(key: "/"): HTMLInputElement | null;
 export function getElementsForKey(key: "Enter"): HTMLElement | null;
-export function getElementsForKey(key: "Escape"): [HTMLElement | null, HTMLElement | null];
-export function getElementsForKey(key: "Tab"): [HTMLElement | null, HTMLElement | null];
-export function getElementsForKey(key: Key): ElementsForKey[Key] 
-{
+export function getElementsForKey(
+  key: "Escape"
+): [HTMLElement | null, HTMLElement | null];
+export function getElementsForKey(
+  key: "Tab"
+): [HTMLElement | null, HTMLElement | null];
+export function getElementsForKey(key: Key): ElementsForKey[Key] {
   // url unrestricted keys
   switch (key) {
-    case "j": {
-      const tableBody = document.querySelector("tbody");
-      const currentItem = tableBody?.querySelector("tr.keyboardSelected") as HTMLTableRowElement;
-      if (currentItem) {
-        const nextItem = getNextNonPendingRow(currentItem, false)
-        setNewRowAsCurrent(nextItem, currentItem)
-        return nextItem;
-      }
-      else {
-        const firstItem = getFirstNonPendingRow(tableBody, false)
-        setNewRowAsCurrent(firstItem, null)
-        return firstItem;
-      }
-    }
-    case "k": {
-      const tableBody = document.querySelector("tbody");
-      const currentItem = tableBody?.querySelector("tr.keyboardSelected") as HTMLTableRowElement;
-      if (currentItem) {
-        const prevItem = getNextNonPendingRow(currentItem, true)
-        if (prevItem) {
-          setNewRowAsCurrent(prevItem, currentItem)
-          return prevItem;
-        } else {
-          return currentItem as HTMLElement | null;
-        }
-      }
-      else {
-        const firstItem = getFirstNonPendingRow(tableBody, false)
-        setNewRowAsCurrent(firstItem, null)
-        return firstItem;
-      }
-    } 
     case "Escape": {
       const clearFilterButton = query("table.p-transactions-table i.x.icon");
 
@@ -141,12 +95,13 @@ export function getElementsForKey(key: Key): ElementsForKey[Key]
   }
 
   // Suggested Recurring shortcuts
-  if (isUrlOneOf(window.location.href, [".*\/recurring\/suggested"]))
-  {
+  if (isUrlOneOf(window.location.href, [".*/recurring/suggested"])) {
     switch (key) {
       case "Enter": {
         const tableBody = document.querySelector("tbody");
-        const currentItem = tableBody?.querySelector("tr.keyboardSelected") as HTMLElement | null;
+        const currentItem = tableBody?.querySelector(
+          "tr.keyboardSelected"
+        ) as HTMLElement | null;
         return currentItem;
       }
       case "a": {
@@ -158,11 +113,10 @@ export function getElementsForKey(key: Key): ElementsForKey[Key]
       }
       case "n": {
         const allButtons = queryAll("button");
-        const noRuleButton = allButtons.find((button) =>
-          button?.textContent == ("No")
+        const noRuleButton = allButtons.find(
+          (button) => button?.textContent == "No"
         );
-        if (noRuleButton != null)
-        {
+        if (noRuleButton != null) {
           return noRuleButton;
         }
         const notRecurringButton = allButtons.find((button) =>
@@ -175,14 +129,13 @@ export function getElementsForKey(key: Key): ElementsForKey[Key]
         const yesButton = allButtons.find((button) =>
           button?.textContent?.includes("Yes")
         ) as HTMLElement | null;
-        return yesButton
+        return yesButton;
       }
     }
   }
 
   // Month navigation shortcuts
-  if (isUrlOneOf(window.location.href, UrlsWithMonths))
-  {
+  if (isUrlOneOf(window.location.href, UrlsWithMonths)) {
     switch (key) {
       case ">": {
         const { year, month } = getCurrentYearAndMonthFromUrl();
@@ -209,27 +162,36 @@ export function getElementsForKey(key: Key): ElementsForKey[Key]
   }
 
   // Transaction Edit shortcuts
-  if (isUrlOneOf(window.location.href, [".*\/transactions\/\d*"]))
-  {
+  if (isUrlOneOf(window.location.href, [".*/transactions/d*"])) {
     const tableBody = document.querySelector("tbody");
     const currentRow = tableBody?.querySelector("tr.keyboardSelected");
     switch (key) {
       case "c": {
-        const categoryField = currentRow?.querySelectorAll("td.editable")[1].
-          querySelector("div")?.querySelector("div")?.querySelector("div") as HTMLElement | null;
+        const categoryField = currentRow
+          ?.querySelectorAll("td.editable")[1]
+          .querySelector("div")
+          ?.querySelector("div")
+          ?.querySelector("div") as HTMLElement | null;
         return categoryField;
       }
       case "p": {
-        const payeeField = currentRow?.querySelectorAll("td.editable")[2].
-          querySelector("div")?.querySelector("div")?.querySelector("div") as HTMLElement | null;
+        const payeeField = currentRow
+          ?.querySelectorAll("td.editable")[2]
+          .querySelector("div")
+          ?.querySelector("div")
+          ?.querySelector("div") as HTMLElement | null;
         return payeeField;
       }
       case "a": {
-        const amountField = currentRow?.querySelectorAll("td.clickable")[1] as HTMLElement | null;
+        const amountField = currentRow?.querySelectorAll(
+          "td.clickable"
+        )[1] as HTMLElement | null;
         return amountField;
       }
       case "x": {
-        const amountField = currentRow?.querySelectorAll("td.clickable")[0] as HTMLElement | null;
+        const amountField = currentRow?.querySelectorAll(
+          "td.clickable"
+        )[0] as HTMLElement | null;
         return amountField;
       }
       case "m": {
@@ -240,26 +202,34 @@ export function getElementsForKey(key: Key): ElementsForKey[Key]
         return markReviewedButton;
       }
       case "n": {
-        const notesField = currentRow?.querySelectorAll("td.editable")[3].
-          querySelector("div")?.querySelector("div")?.querySelector("div") as HTMLElement | null;
+        const notesField = currentRow
+          ?.querySelectorAll("td.editable")[3]
+          .querySelector("div")
+          ?.querySelector("div")
+          ?.querySelector("div") as HTMLElement | null;
         return notesField;
       }
       case "t": {
         const rowButtons = currentRow?.querySelectorAll("button");
-        if (rowButtons == null)
-        {
-          return null
+        if (rowButtons == null) {
+          return null;
         }
         const rowButtonsArray = Array.from(rowButtons);
-        const addTagButton = rowButtonsArray?.find((button) => button?.textContent?.includes("Add")) as HTMLElement | null;
+        const addTagButton = rowButtonsArray?.find((button) =>
+          button?.textContent?.includes("Add")
+        ) as HTMLElement | null;
         return addTagButton;
       }
       case "r": {
-        const markReviewedButton = currentRow?.querySelector("i.check.circle.icon") as HTMLElement | null;
+        const markReviewedButton = currentRow?.querySelector(
+          "i.check.circle.icon"
+        ) as HTMLElement | null;
         return markReviewedButton;
       }
       case "Enter": {
-        const detailsButton = currentRow?.querySelector("i.angle.right.icon") as HTMLElement | null;
+        const detailsButton = currentRow?.querySelector(
+          "i.angle.right.icon"
+        ) as HTMLElement | null;
         return detailsButton;
       }
       case "/": {
@@ -277,28 +247,4 @@ export function getElementsForKey(key: Key): ElementsForKey[Key]
 export function getElementsForUnknownKey(key: string): (HTMLElement | null)[] {
   const elements = getElementsForKey(key as any);
   return Array.isArray(elements) ? elements : [elements];
-}
-
-
-// Function to reset the Transaction Keyboard Selection
-export function resetTransactionKeyboardSelection() {
-  lastActiveRowIndex = "";
-}
-
-// Function to restore the last active row from after Transaction table update
-export function restoreTransactionKeyboardSelection() {
-  if (lastActiveRowIndex !== "") {
-    const rowIndex = parseInt(lastActiveRowIndex);
-    if (!isNaN(rowIndex)) {
-      // Query the table body for the row element at the saved rowIndex
-      const querySelector = `tbody tr:nth-child(${rowIndex})`;
-      const rowElement = document.querySelector(querySelector);
-
-      // Set that current row ad Keyboard Selected and ensure it is in view
-      if (rowElement) {
-        rowElement.classList.add('keyboardSelected');
-        rowElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      }
-    }
-  }
 }

--- a/src/utils/getElementForKey.ts
+++ b/src/utils/getElementForKey.ts
@@ -178,7 +178,7 @@ export function getElementsForKey(key: Key): ElementsForKey[Key]
         return categoryButton;
       }
       case "r": {
-        const markReviewedButton = query("i.check.circle.icon");
+        const markReviewedButton = currentRow.querySelector("i.check.circle.icon") as HTMLElement | null;
         return markReviewedButton;
       }
       case "/": {

--- a/src/utils/getElementForKey.ts
+++ b/src/utils/getElementForKey.ts
@@ -5,9 +5,15 @@ import { getNextMonthUrl, getPreviousMonthUrl } from "./monthNavigation";
 export const query = (selector: string) =>
   document.querySelector(selector) as HTMLElement | null;
 export const queryAll = (selector: string) =>
-  document.querySelectorAll(selector) as NodeListOf<HTMLElement>;
+  Array.from(document.querySelectorAll(selector) as NodeListOf<HTMLElement>);
 
-type Key = "n" | "p" | "r" | "t" | "/" | "Escape" | "Tab";
+const UrlsWithMonths = [".*\/(transactions|budget|recurring|calendar)\/\d*"];
+
+function isUrlOneOf(url: string, allowedUrls: string[]) {
+  return allowedUrls.some(pattern => url.match(pattern))
+}
+
+type Key = "j" | "k" | "c" | "a" | "n" | "p" | "r" | "t" | "/" | "Enter" | "Escape" | "Tab";
 type ElementsForKey = {
   [K in Key]: K extends "/"
     ? HTMLInputElement | null
@@ -16,78 +22,174 @@ type ElementsForKey = {
     : HTMLElement | null;
 };
 
+export function getElementsForKey(key: "j"): HTMLElement | null;
+export function getElementsForKey(key: "k"): HTMLElement | null;
+export function getElementsForKey(key: "c"): HTMLElement | null;
+export function getElementsForKey(key: "a"): HTMLElement | null;
 export function getElementsForKey(key: "n"): HTMLElement | null;
 export function getElementsForKey(key: "p"): HTMLElement | null;
 export function getElementsForKey(key: "r"): HTMLElement | null;
 export function getElementsForKey(key: "t"): HTMLElement | null;
 export function getElementsForKey(key: "/"): HTMLInputElement | null;
-export function getElementsForKey(
-  key: "Escape"
-): [HTMLElement | null, HTMLElement | null];
-export function getElementsForKey(
-  key: "Tab"
-): [HTMLElement | null, HTMLElement | null];
-export function getElementsForKey(key: Key): ElementsForKey[Key] {
+export function getElementsForKey(key: "Enter"): HTMLElement | null;
+export function getElementsForKey(key: "Escape"): [HTMLElement | null, HTMLElement | null];
+export function getElementsForKey(key: "Tab"): [HTMLElement | null, HTMLElement | null];
+export function getElementsForKey(key: Key): ElementsForKey[Key] 
+{
+  // url unrestricted keys
   switch (key) {
-    case "n": {
-      const { year, month } = getCurrentYearAndMonthFromUrl();
-      const nextMonthButton = query(
-        `a[href*="${getNextMonthUrl(month, year)}"]`
-      );
-      return nextMonthButton;
+    case "j": {
+      const tableBody = document.querySelector("tbody");
+      const currentItem = tableBody?.querySelector("tr.keyboardSelected");
+      if (currentItem) {
+        const nextItem = currentItem.nextElementSibling as HTMLElement | null;
+        currentItem.classList.remove('keyboardSelected');
+        nextItem?.classList.add('keyboardSelected');
+        return nextItem;
+      }
+      else {
+        const firstItem = tableBody?.querySelector("tr") as HTMLElement | null;
+        firstItem?.classList.add('keyboardSelected');
+        return firstItem;
+      }
     }
-    case "p": {
-      const { year, month } = getCurrentYearAndMonthFromUrl();
-      const previousMonthButton = query(
-        `a[href*="${getPreviousMonthUrl(month, year)}"]`
-      );
-      return previousMonthButton;
-    }
-    case "r": {
-      const reviewTransactionsButton = query("div.task-card");
-      return reviewTransactionsButton;
-    }
-    case "t": {
-      const allButtons = queryAll("button");
-      const thisMonthButton = Array.from(allButtons).find((button) =>
-        button?.textContent?.includes("Back to this month")
-      );
-      return thisMonthButton || null;
-    }
-    case "/": {
-      const quickFilterInput = document.getElementById(
-        "search-transactions-input"
-      ) as HTMLInputElement | null;
-      return quickFilterInput;
-    }
-    case "Escape": {
-      const clearFilterButton = query("table.p-transactions-table i.x.icon");
+    case "k": {
+      const tableBody = document.querySelector("tbody");
+      const currentItem = tableBody?.querySelector("tr.keyboardSelected");
+      if (currentItem) {
+        const prevItem = currentItem.previousElementSibling as HTMLElement | null;
+        if (prevItem) {
+          currentItem.classList.remove("keyboardSelected");
+          prevItem.classList.add("keyboardSelected");
+          return prevItem;
+        }
+      }
+      else {
+        const firstItem = tableBody?.querySelector("tr") as HTMLElement | null;
+        firstItem?.classList.add("keyboardSelected");
+        return firstItem;
+      }
+    } 
+  }
 
-      const footerButtons = queryAll("div.modal .modal-footer button");
-      const modalCloseButton = Array.from(footerButtons).find((button) => {
-        const buttonText = button?.textContent?.toLowerCase();
-        return buttonText?.includes("close") || buttonText?.includes("cancel");
-      }) as HTMLElement | null;
-
-      return [clearFilterButton, modalCloseButton];
-    }
-    case "Tab": {
-      const allSubNavs = queryAll("div.secondary.menu a");
-      const numSubNavs = allSubNavs.length;
-      const activeSubNavIndex = Array.from(allSubNavs).findIndex((subNav) =>
-        subNav.classList.contains("active")
-      );
-
-      const nextSubNavIndex =
-        activeSubNavIndex + 1 > numSubNavs - 1 ? 0 : activeSubNavIndex + 1;
-      const nextNavElement = allSubNavs[nextSubNavIndex];
-      const previousSubNavIndex =
-        activeSubNavIndex - 1 < 0 ? numSubNavs - 1 : activeSubNavIndex - 1;
-      const previousNavElement = allSubNavs[previousSubNavIndex];
-
-      return [previousNavElement, nextNavElement];
+  // Suggested Recurring shortcuts
+  if (isUrlOneOf(window.location.href, [".*\/recurring\/suggested"]))
+  {
+    switch (key) {
+      case "Enter": {
+        const tableBody = document.querySelector("tbody");
+        const currentItem = tableBody?.querySelector("tr.keyboardSelected") as HTMLElement | null;
+        return currentItem;
+      }
+      case "a": {
+        const allButtons = queryAll("button");
+        const notRecurringButton = allButtons.find((button) =>
+          button?.textContent?.includes("APPROVE THIS NEW RECURRING ITEM")
+        );
+        return notRecurringButton ? notRecurringButton : null;
+      }
+      case "n": {
+        const allButtons = queryAll("button");
+        const noRuleButton = allButtons.find((button) =>
+          button?.textContent == ("No")
+        );
+        if (noRuleButton != null)
+        {
+          return noRuleButton;
+        }
+        const notRecurringButton = allButtons.find((button) =>
+          button?.textContent?.includes("not a recurring item")
+        );
+        return notRecurringButton ? notRecurringButton : null;
+      }
     }
   }
+
+  // Month navigation shortcuts
+  if (isUrlOneOf(window.location.href, UrlsWithMonths))
+  {
+    switch (key) {
+      case "n": {
+        const { year, month } = getCurrentYearAndMonthFromUrl();
+        const nextMonthButton = query(
+          `a[href*="${getNextMonthUrl(month, year)}"]`
+        );
+        return nextMonthButton;
+      }
+      case "p": {
+        const { year, month } = getCurrentYearAndMonthFromUrl();
+        const previousMonthButton = query(
+          `a[href*="${getPreviousMonthUrl(month, year)}"]`
+        );
+        return previousMonthButton;
+      }
+      case "t": {
+        const allButtons = queryAll("button");
+        const thisMonthButton = Array.from(allButtons).find((button) =>
+          button?.textContent?.includes("Back to this month")
+        );
+        return thisMonthButton || null;
+      }
+      case "Escape": {
+        const clearFilterButton = query("table.p-transactions-table i.x.icon");
+
+        const footerButtons = queryAll("div.modal .modal-footer button");
+        const modalCloseButton = Array.from(footerButtons).find((button) => {
+          const buttonText = button?.textContent?.toLowerCase();
+          return buttonText?.includes("close") || buttonText?.includes("cancel");
+        }) as HTMLElement | null;
+
+        return [clearFilterButton, modalCloseButton];
+      }
+      case "Tab": {
+        const allSubNavs = queryAll("div.secondary.menu a");
+        const numSubNavs = allSubNavs.length;
+        const activeSubNavIndex = Array.from(allSubNavs).findIndex((subNav) =>
+          subNav.classList.contains("active")
+        );
+
+        const nextSubNavIndex =
+          activeSubNavIndex + 1 > numSubNavs - 1 ? 0 : activeSubNavIndex + 1;
+        const nextNavElement = allSubNavs[nextSubNavIndex];
+        const previousSubNavIndex =
+          activeSubNavIndex - 1 < 0 ? numSubNavs - 1 : activeSubNavIndex - 1;
+        const previousNavElement = allSubNavs[previousSubNavIndex];
+
+        return [previousNavElement, nextNavElement];
+      }
+    }
+  }
+
+  // Transaction Edit shortcuts
+  if (isUrlOneOf(window.location.href, [".*\/transactions\/\d*"]))
+  {
+    const tableBody = document.querySelector("tbody");
+    const currentRow = tableBody?.querySelector("tr.keyboardSelected");
+    if (currentRow == null)
+    {
+      return null;
+    }
+    switch (key) {
+      case "c": {
+        const categoryButton = currentRow.querySelectorAll("td.editable")[1].
+          querySelector("div")?.querySelector("div") as HTMLElement | null;
+        console.log("found category:")
+        console.log(categoryButton);
+        return categoryButton;
+      }
+      case "r": {
+        const markReviewedButton = query("i.check.circle.icon");
+        return markReviewedButton;
+      }
+      case "/": {
+        const quickFilterInput = document.getElementById(
+          "search-transactions-input"
+        ) as HTMLInputElement | null;
+        return quickFilterInput;
+      }
+    }
+  }
+
   return null;
 }
 

--- a/src/utils/getElementForKey.ts
+++ b/src/utils/getElementForKey.ts
@@ -13,7 +13,7 @@ function isUrlOneOf(url: string, allowedUrls: string[]) {
   return allowedUrls.some(pattern => url.match(pattern))
 }
 
-type Key = "j" | "k" | "c" | "a" | "n" | "p" | "r" | "t" | "/" | "Enter" | "Escape" | "Tab";
+type Key = "j" | "k" | "c" | "a" | "n" | "p" | "x" | "m" | "r" | "t" | ">" | "<" | "." | "/" | "Enter" | "Escape" | "Tab";
 type ElementsForKey = {
   [K in Key]: K extends "/"
     ? HTMLInputElement | null
@@ -28,8 +28,13 @@ export function getElementsForKey(key: "c"): HTMLElement | null;
 export function getElementsForKey(key: "a"): HTMLElement | null;
 export function getElementsForKey(key: "n"): HTMLElement | null;
 export function getElementsForKey(key: "p"): HTMLElement | null;
+export function getElementsForKey(key: "x"): HTMLElement | null;
+export function getElementsForKey(key: "m"): HTMLElement | null;
 export function getElementsForKey(key: "r"): HTMLElement | null;
 export function getElementsForKey(key: "t"): HTMLElement | null;
+export function getElementsForKey(key: ">"): HTMLElement | null;
+export function getElementsForKey(key: "<"): HTMLElement | null;
+export function getElementsForKey(key: "."): HTMLElement | null;
 export function getElementsForKey(key: "/"): HTMLInputElement | null;
 export function getElementsForKey(key: "Enter"): HTMLElement | null;
 export function getElementsForKey(key: "Escape"): [HTMLElement | null, HTMLElement | null];
@@ -70,6 +75,33 @@ export function getElementsForKey(key: Key): ElementsForKey[Key]
         return firstItem;
       }
     } 
+      case "Escape": {
+        const clearFilterButton = query("table.p-transactions-table i.x.icon");
+
+        const footerButtons = queryAll("div.modal .modal-footer button");
+        const modalCloseButton = Array.from(footerButtons).find((button) => {
+          const buttonText = button?.textContent?.toLowerCase();
+          return buttonText?.includes("close") || buttonText?.includes("cancel");
+        }) as HTMLElement | null;
+
+        return [clearFilterButton, modalCloseButton];
+      }
+      case "Tab": {
+        const allSubNavs = queryAll("div.secondary.menu a");
+        const numSubNavs = allSubNavs.length;
+        const activeSubNavIndex = Array.from(allSubNavs).findIndex((subNav) =>
+          subNav.classList.contains("active")
+        );
+
+        const nextSubNavIndex =
+          activeSubNavIndex + 1 > numSubNavs - 1 ? 0 : activeSubNavIndex + 1;
+        const nextNavElement = allSubNavs[nextSubNavIndex];
+        const previousSubNavIndex =
+          activeSubNavIndex - 1 < 0 ? numSubNavs - 1 : activeSubNavIndex - 1;
+        const previousNavElement = allSubNavs[previousSubNavIndex];
+
+        return [previousNavElement, nextNavElement];
+      }
   }
 
   // Suggested Recurring shortcuts
@@ -109,53 +141,26 @@ export function getElementsForKey(key: Key): ElementsForKey[Key]
   if (isUrlOneOf(window.location.href, UrlsWithMonths))
   {
     switch (key) {
-      case "n": {
+      case ">": {
         const { year, month } = getCurrentYearAndMonthFromUrl();
         const nextMonthButton = query(
           `a[href*="${getNextMonthUrl(month, year)}"]`
         );
         return nextMonthButton;
       }
-      case "p": {
+      case "<": {
         const { year, month } = getCurrentYearAndMonthFromUrl();
         const previousMonthButton = query(
           `a[href*="${getPreviousMonthUrl(month, year)}"]`
         );
         return previousMonthButton;
       }
-      case "t": {
+      case ".": {
         const allButtons = queryAll("button");
         const thisMonthButton = Array.from(allButtons).find((button) =>
           button?.textContent?.includes("Back to this month")
         );
         return thisMonthButton || null;
-      }
-      case "Escape": {
-        const clearFilterButton = query("table.p-transactions-table i.x.icon");
-
-        const footerButtons = queryAll("div.modal .modal-footer button");
-        const modalCloseButton = Array.from(footerButtons).find((button) => {
-          const buttonText = button?.textContent?.toLowerCase();
-          return buttonText?.includes("close") || buttonText?.includes("cancel");
-        }) as HTMLElement | null;
-
-        return [clearFilterButton, modalCloseButton];
-      }
-      case "Tab": {
-        const allSubNavs = queryAll("div.secondary.menu a");
-        const numSubNavs = allSubNavs.length;
-        const activeSubNavIndex = Array.from(allSubNavs).findIndex((subNav) =>
-          subNav.classList.contains("active")
-        );
-
-        const nextSubNavIndex =
-          activeSubNavIndex + 1 > numSubNavs - 1 ? 0 : activeSubNavIndex + 1;
-        const nextNavElement = allSubNavs[nextSubNavIndex];
-        const previousSubNavIndex =
-          activeSubNavIndex - 1 < 0 ? numSubNavs - 1 : activeSubNavIndex - 1;
-        const previousNavElement = allSubNavs[previousSubNavIndex];
-
-        return [previousNavElement, nextNavElement];
       }
     }
   }
@@ -165,21 +170,54 @@ export function getElementsForKey(key: Key): ElementsForKey[Key]
   {
     const tableBody = document.querySelector("tbody");
     const currentRow = tableBody?.querySelector("tr.keyboardSelected");
-    if (currentRow == null)
-    {
-      return null;
-    }
     switch (key) {
       case "c": {
-        const categoryButton = currentRow.querySelectorAll("td.editable")[1].
-          querySelector("div")?.querySelector("div") as HTMLElement | null;
-        console.log("found category:")
-        console.log(categoryButton);
-        return categoryButton;
+        const categoryField = currentRow?.querySelectorAll("td.editable")[1].
+          querySelector("div")?.querySelector("div")?.querySelector("div") as HTMLElement | null;
+        return categoryField;
+      }
+      case "p": {
+        const payeeField = currentRow?.querySelectorAll("td.editable")[2].
+          querySelector("div")?.querySelector("div")?.querySelector("div") as HTMLElement | null;
+        return payeeField;
+      }
+      case "a": {
+        const amountField = currentRow?.querySelectorAll("td.clickable")[1] as HTMLElement | null;
+        return amountField;
+      }
+      case "x": {
+        const amountField = currentRow?.querySelectorAll("td.clickable")[0] as HTMLElement | null;
+        return amountField;
+      }
+      case "m": {
+        const allButtons = queryAll("button");
+        const markReviewedButton = allButtons.find((button) =>
+          button?.textContent?.includes("Mark Reviewed")
+        ) as HTMLElement | null;
+        return markReviewedButton;
+      }
+      case "n": {
+        const notesField = currentRow?.querySelectorAll("td.editable")[3].
+          querySelector("div")?.querySelector("div")?.querySelector("div") as HTMLElement | null;
+        return notesField;
+      }
+      case "t": {
+        const rowButtons = currentRow?.querySelectorAll("button");
+        if (rowButtons == null)
+        {
+          return null
+        }
+        const rowButtonsArray = Array.from(rowButtons);
+        const addTagButton = rowButtonsArray?.find((button) => button?.textContent?.includes("Add")) as HTMLElement | null;
+        return addTagButton;
       }
       case "r": {
-        const markReviewedButton = currentRow.querySelector("i.check.circle.icon") as HTMLElement | null;
+        const markReviewedButton = currentRow?.querySelector("i.check.circle.icon") as HTMLElement | null;
         return markReviewedButton;
+      }
+      case "Enter": {
+        const detailsButton = currentRow?.querySelector("i.angle.right.icon") as HTMLElement | null;
+        return detailsButton;
       }
       case "/": {
         const quickFilterInput = document.getElementById(

--- a/src/utils/getElementForKey.ts
+++ b/src/utils/getElementForKey.ts
@@ -13,7 +13,7 @@ function isUrlOneOf(url: string, allowedUrls: string[]) {
   return allowedUrls.some(pattern => url.match(pattern))
 }
 
-type Key = "j" | "k" | "c" | "a" | "n" | "p" | "x" | "m" | "r" | "t" | ">" | "<" | "." | "/" | "Enter" | "Escape" | "Tab";
+type Key = "j" | "k" | "c" | "a" | "n" | "p" | "x" | "m" | "r" | "t" | "y" | ">" | "<" | "." | "/" | "Enter" | "Escape" | "Tab";
 type ElementsForKey = {
   [K in Key]: K extends "/"
     ? HTMLInputElement | null
@@ -32,6 +32,7 @@ export function getElementsForKey(key: "x"): HTMLElement | null;
 export function getElementsForKey(key: "m"): HTMLElement | null;
 export function getElementsForKey(key: "r"): HTMLElement | null;
 export function getElementsForKey(key: "t"): HTMLElement | null;
+export function getElementsForKey(key: "y"): HTMLElement | null;
 export function getElementsForKey(key: ">"): HTMLElement | null;
 export function getElementsForKey(key: "<"): HTMLElement | null;
 export function getElementsForKey(key: "."): HTMLElement | null;
@@ -116,7 +117,7 @@ export function getElementsForKey(key: Key): ElementsForKey[Key]
       case "a": {
         const allButtons = queryAll("button");
         const notRecurringButton = allButtons.find((button) =>
-          button?.textContent?.includes("APPROVE THIS NEW RECURRING ITEM")
+          button?.textContent?.includes("Approve this new recurring item")
         );
         return notRecurringButton ? notRecurringButton : null;
       }
@@ -133,6 +134,13 @@ export function getElementsForKey(key: Key): ElementsForKey[Key]
           button?.textContent?.includes("not a recurring item")
         );
         return notRecurringButton ? notRecurringButton : null;
+      }
+      case "y": {
+        const allButtons = queryAll("button");
+        const yesButton = allButtons.find((button) =>
+          button?.textContent?.includes("Yes")
+        ) as HTMLElement | null;
+        return yesButton
       }
     }
   }

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -3,6 +3,8 @@ const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
 const srcDir = path.join(__dirname, "..", "src");
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+
 
 module.exports = {
   entry: {
@@ -62,6 +64,7 @@ module.exports = {
       options: {},
     }),
     new webpack.HotModuleReplacementPlugin(),
+    new CleanWebpackPlugin(),
   ],
   devServer: {
     hot: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -749,6 +749,14 @@
   resolved "https://registry.yarnpkg.com/@types/filewriter/-/filewriter-0.0.29.tgz#a48795ecadf957f6c0d10e0c34af86c098fa5bee"
   integrity sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==
 
+"@types/glob@^7.1.1":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
+  integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -819,6 +827,11 @@
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.4.tgz#a4ed836e069491414bab92c31fdea9e557aca0d9"
   integrity sha512-1Gjee59G25MrQGk8bsNvC6fxNiRgUlGn2wlhGf95a59DrprnnHk80FIMMFG9XHMdrfsuA119ht06QPDXA1Z7tw==
+
+"@types/minimatch@*":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
+  integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/node-forge@^1.3.0":
   version "1.3.8"
@@ -1303,10 +1316,22 @@ array-flatten@^2.1.2:
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.2.tgz#24ef80a28c1a893617e2149b0c6d0d788293b099"
   integrity sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==
 
+array-union@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
+  integrity sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==
+  dependencies:
+    array-uniq "^1.0.1"
+
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
+array-uniq@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
+  integrity sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -1594,6 +1619,13 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
+clean-webpack-plugin@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-4.0.0.tgz#72947d4403d452f38ed61a9ff0ada8122aacd729"
+  integrity sha512-WuWE1nyTNAyW5T7oNyys2EN0cfP2fdRxhxnIQWiAp0bMabPdHhoGxM8A6YL2GhqwgrPnnaemVE7nv5XJ2Fhh2w==
+  dependencies:
+    del "^4.1.1"
+
 cliui@^7.0.2:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
@@ -1880,6 +1912,19 @@ define-lazy-prop@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
   integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+
+del@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/del/-/del-4.1.1.tgz#9e8f117222ea44a31ff3a156c049b99052a9f0b4"
+  integrity sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==
+  dependencies:
+    "@types/glob" "^7.1.1"
+    globby "^6.1.0"
+    is-path-cwd "^2.0.0"
+    is-path-in-cwd "^2.0.0"
+    p-map "^2.0.0"
+    pify "^4.0.1"
+    rimraf "^2.6.3"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -2388,7 +2433,7 @@ glob@7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -2416,6 +2461,17 @@ globby@^11.0.3:
     ignore "^5.2.0"
     merge2 "^1.4.1"
     slash "^3.0.0"
+
+globby@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
+  integrity sha512-KVbFv2TQtbzCoxAnfD6JcHZTYCzyliEaaeM/gH8qQdkKr5s0OP9scEgvdcngyk7AVdY6YVW/TJHd+lQ/Df3Daw==
+  dependencies:
+    array-union "^1.0.1"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 gopd@^1.0.1:
   version "1.0.1"
@@ -2708,6 +2764,25 @@ is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-path-cwd@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
+  integrity sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
+
+is-path-in-cwd@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz#bfe2dca26c69f397265a4009963602935a053acb"
+  integrity sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==
+  dependencies:
+    is-path-inside "^2.1.0"
+
+is-path-inside@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-2.1.0.tgz#7c9810587d659a40d27bcdb4d5616eab059494b2"
+  integrity sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==
+  dependencies:
+    path-is-inside "^1.0.2"
 
 is-plain-obj@^3.0.0:
   version "3.0.0"
@@ -3685,6 +3760,11 @@ p-locate@^4.1.0:
   dependencies:
     p-limit "^2.2.0"
 
+p-map@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
+  integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
+
 p-retry@^4.5.0:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
@@ -3735,6 +3815,11 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
+path-is-inside@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+  integrity sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==
+
 path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
@@ -3765,10 +3850,27 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-pify@^2.3.0:
+pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
   integrity sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==
+
+pify@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
+pinkie-promise@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
+  integrity sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==
+  dependencies:
+    pinkie "^2.0.0"
+
+pinkie@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+  integrity sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==
 
 pirates@^4.0.1:
   version "4.0.6"
@@ -4105,6 +4207,13 @@ reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
+rimraf@^2.6.3:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
 
 rimraf@^3.0.0, rimraf@^3.0.2, "rimraf@^3.0.2 ":
   version "3.0.2"


### PR DESCRIPTION
## Description:
This PR contains all of the changes proposed by @skylyn and @jpjpjp from the [fork/main branch](https://github.com/skylyn/moneymover).

Added:
- A `TransactionTable` module which consolidates all the transaction table module into a single file
- A "gg" command which will select the top item of the transaction table
- (Adam) Modified the `.keyboardSelected` class to use the "Lunch Money Yellow" color 
- A webpack plugin to keep the `dist` dir clean

## References:
- Original fork: https://github.com/skylyn/moneymover
- Discord link for @jpjpjp 's contribution: https://discord.com/channels/842337014556262411/1134594277134057512/1218359225378541681


## Left to-do:
- [ ] Table wrapping? (i.e. `j` on bottom row wraps to top row, and vice versa)