### PR TITLE
Dont invoke plugin on feedback.lunchmoney.com

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -18,7 +18,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://*.lunchmoney.app/*"],
+      "matches": ["https://my.lunchmoney.app/*", "https://beta.lunchmoney.app/*"],
       "js": ["js/vendor.js", "js/content_script.js"]
     }
   ],


### PR DESCRIPTION
I noticed that money mover was preventing me from  creating new entries or commenting on existing entries on feedback.lunchmoney.app.   This small change makes it so that the plugin is only active on my.lunchmoney.app and beta.lunchmoney.app.